### PR TITLE
[Core] Fix prototype.js polyfill

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-core",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Ensures consistent encoding and decoding of TC Signals for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",

--- a/modules/core/src/model/PurposeRestrictionVector.ts
+++ b/modules/core/src/model/PurposeRestrictionVector.ts
@@ -151,7 +151,13 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
     /**
      * Create an ordered array of vendor IDs from `1` (the minimum value for Vendor ID) to `lastEntry`
      */
-    const values = [...Array(lastEntry).keys()].map( (i) => i + 1);
+    const values = [];
+
+    for (let i = 0; i < lastEntry; i++) {
+
+      values[i] = i + 1;
+
+    }
 
     for (let i = 1; i <= lastEntry; i++) {
 
@@ -168,7 +174,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
        * need to add an additional de-duplication here.
        */
 
-      this.map.get(hash).add(i);
+      this.map.get(hash)?.add(i);
 
     }
 


### PR DESCRIPTION
We have an issue with `core` module `restrictPurposeToLegalBasis` that does not work well with `prototype.js` polyfill (see pic.) Looks like `[...Array(lastEntry).keys()]` with `prototype.js` polyfil is not working well and return empty array.

This PR implements more simple approach to generate IDs array (`values`) to avoid possible using of polyfill in this case. It also add conditional call to avoid crash for `null` value.

![Screenshot 2023-05-17 at 11 51 54](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/assets/5311893/3c1ad535-1844-4058-ac80-b28d497721de)