### PR TITLE
[TCF v2.2] Use `useNonStandardTexts` instead of `useNonStandardStacks`  

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -32,7 +32,7 @@ created: Mon Dec 09 2019 00:00:00 GMT
 lastUpdated: Mon Dec 09 2019 00:00:00 GMT
 policyVersion: 2
 isServiceSpecific: false
-useNonStandardStacks: false
+useNonStandardTexts: false
 purposeOneTreatment: false
 publisherCountryCode: "ES"
 supportOOB: false

--- a/modules/cli/src/index.ts
+++ b/modules/cli/src/index.ts
@@ -89,7 +89,7 @@ if (encoded) {
 
       print('policyVersion', tcModel.policyVersion);
       print('isServiceSpecific', tcModel.isServiceSpecific);
-      print('useNonStandardStacks', tcModel.useNonStandardStacks);
+      print('useNonStandardTexts', tcModel.useNonStandardTexts);
       print('purposeOneTreatment', tcModel.purposeOneTreatment);
       print('publisherCountryCode', tcModel.publisherCountryCode);
 

--- a/modules/cmpapi/src/response/TCData.ts
+++ b/modules/cmpapi/src/response/TCData.ts
@@ -14,7 +14,7 @@ export class TCData extends Response {
   public eventStatus: EventStatus;
   public cmpStatus: CmpStatus;
   public isServiceSpecific: Booleany;
-  public useNonStandardStacks: Booleany;
+  public useNonStandardTexts: Booleany;
   public publisherCC: string;
   public purposeOneTreatment: Booleany;
 
@@ -78,7 +78,7 @@ export class TCData extends Response {
 
       this.tcString = CmpApiModel.tcString;
       this.isServiceSpecific = tcModel.isServiceSpecific;
-      this.useNonStandardStacks = tcModel.useNonStandardStacks;
+      this.useNonStandardTexts = tcModel.useNonStandardTexts;
       this.purposeOneTreatment = tcModel.purposeOneTreatment;
       this.publisherCC = tcModel.publisherCountryCode;
 

--- a/modules/cmpapi/test/TestUtils.ts
+++ b/modules/cmpapi/test/TestUtils.ts
@@ -68,7 +68,7 @@ export class TestUtils {
     expect(inAppTCData.tcString, 'tcString').to.equal(TCString.encode(tcModel));
     expect(inAppTCData.eventStatus, 'eventStatus').to.equal(CmpApiModel.eventStatus);
     expect(inAppTCData.isServiceSpecific, 'isServiceSpecific').to.equal(tcModel.isServiceSpecific);
-    expect(inAppTCData.useNonStandardStacks, 'useNonStandardStacks').to.equal(tcModel.useNonStandardStacks);
+    expect(inAppTCData.useNonStandardTexts, 'useNonStandardTexts').to.equal(tcModel.useNonStandardTexts);
     expect(inAppTCData.purposeOneTreatment, 'purposeOneTreatment').to.equal(tcModel.purposeOneTreatment);
     expect(inAppTCData.publisherCC, 'publisherCC').to.equal(tcModel.publisherCountryCode);
     expect(inAppTCData.outOfBand, 'outOfBand').to.be.undefined;
@@ -141,7 +141,7 @@ export class TestUtils {
     expect(tcData.eventStatus, 'eventStatus').to.equal(CmpApiModel.eventStatus);
     expect(tcData.cmpStatus, 'cmpStatus').to.equal(CmpApiModel.cmpStatus);
     expect(tcData.isServiceSpecific, 'isServiceSpecific').to.equal(tcModel.isServiceSpecific);
-    expect(tcData.useNonStandardStacks, 'useNonStandardStacks').to.equal(tcModel.useNonStandardStacks);
+    expect(tcData.useNonStandardTexts, 'useNonStandardTexts').to.equal(tcModel.useNonStandardTexts);
     expect(tcData.purposeOneTreatment, 'purposeOneTreatment').to.equal(tcModel.purposeOneTreatment);
     expect(tcData.publisherCC, 'publisherCC').to.equal(tcModel.publisherCountryCode);
 

--- a/modules/cmpapi/test/response/TCData.test.ts
+++ b/modules/cmpapi/test/response/TCData.test.ts
@@ -37,7 +37,7 @@ describe('response->TCData', (): void => {
     expect(tcData.cmpStatus, 'cmpStatus').to.equal(CmpApiModel.cmpStatus);
 
     expect(tcData.isServiceSpecific, 'isServiceSpecific').to.be.undefined;
-    expect(tcData.useNonStandardStacks, 'useNonStandardStacks').to.be.undefined;
+    expect(tcData.useNonStandardTexts, 'useNonStandardTexts').to.be.undefined;
     expect(tcData.purposeOneTreatment, 'purposeOneTreatment').to.be.undefined;
     expect(tcData.publisherCC, 'publisherCC').to.be.undefined;
 

--- a/modules/core/src/TCModel.ts
+++ b/modules/core/src/TCModel.ts
@@ -16,7 +16,7 @@ export class TCModel extends Cloneable<TCModel> {
 
   private isServiceSpecific_ = false;
   private supportOOB_ = true;
-  private useNonStandardStacks_ = false;
+  private useNonStandardTexts_ = false;
   private purposeOneTreatment_ = false;
   private publisherCountryCode_ = 'AA';
   private version_ = 2;
@@ -434,15 +434,15 @@ export class TCModel extends Cloneable<TCModel> {
    *
    * @param {boolean} bool - value to set
    */
-  public set useNonStandardStacks(bool: boolean) {
+  public set useNonStandardTexts(bool: boolean) {
 
-    this.useNonStandardStacks_ = bool;
+    this.useNonStandardTexts_ = bool;
 
   }
 
-  public get useNonStandardStacks(): boolean {
+  public get useNonStandardTexts(): boolean {
 
-    return this.useNonStandardStacks_;
+    return this.useNonStandardTexts_;
 
   }
 

--- a/modules/core/src/encoder/BitLength.ts
+++ b/modules/core/src/encoder/BitLength.ts
@@ -17,7 +17,7 @@ export class BitLength {
   public static readonly [Fields.purposeLegitimateInterests]: number = 24;
   public static readonly [Fields.purposeOneTreatment]: number = 1;
   public static readonly [Fields.specialFeatureOptins]: number = 12;
-  public static readonly [Fields.useNonStandardStacks]: number = 1;
+  public static readonly [Fields.useNonStandardTexts]: number = 1;
   public static readonly [Fields.vendorListVersion]: number = 12;
   public static readonly [Fields.version]: number = 6;
 

--- a/modules/core/src/encoder/field/FieldEncoderMap.ts
+++ b/modules/core/src/encoder/field/FieldEncoderMap.ts
@@ -20,7 +20,7 @@ export function FieldEncoderMap(): object {
     [Fields.vendorListVersion]: IntEncoder,
     [Fields.policyVersion]: IntEncoder,
     [Fields.isServiceSpecific]: BooleanEncoder,
-    [Fields.useNonStandardStacks]: BooleanEncoder,
+    [Fields.useNonStandardTexts]: BooleanEncoder,
     [Fields.specialFeatureOptins]: FixedVectorEncoder,
     [Fields.purposeConsents]: FixedVectorEncoder,
     [Fields.purposeLegitimateInterests]: FixedVectorEncoder,

--- a/modules/core/src/encoder/sequence/FieldSequence.ts
+++ b/modules/core/src/encoder/sequence/FieldSequence.ts
@@ -29,7 +29,7 @@ export class FieldSequence implements SequenceVersionMap {
       Fields.vendorListVersion,
       Fields.policyVersion,
       Fields.isServiceSpecific,
-      Fields.useNonStandardStacks,
+      Fields.useNonStandardTexts,
       Fields.specialFeatureOptins,
       Fields.purposeConsents,
       Fields.purposeLegitimateInterests,

--- a/modules/core/src/model/Fields.ts
+++ b/modules/core/src/model/Fields.ts
@@ -20,7 +20,7 @@ export class Fields {
   public static readonly purposeLegitimateInterests: 'purposeLegitimateInterests' = 'purposeLegitimateInterests';
   public static readonly purposeOneTreatment: 'purposeOneTreatment' = 'purposeOneTreatment';
   public static readonly specialFeatureOptins: 'specialFeatureOptins' = 'specialFeatureOptins';
-  public static readonly useNonStandardStacks: 'useNonStandardStacks' = 'useNonStandardStacks';
+  public static readonly useNonStandardTexts: 'useNonStandardTexts' = 'useNonStandardTexts';
   public static readonly vendorConsents: 'vendorConsents' = 'vendorConsents';
   public static readonly vendorLegitimateInterests: 'vendorLegitimateInterests' = 'vendorLegitimateInterests';
   public static readonly vendorListVersion: 'vendorListVersion' = 'vendorListVersion';

--- a/modules/core/test/TCModel.test.ts
+++ b/modules/core/test/TCModel.test.ts
@@ -193,7 +193,7 @@ describe('TCModel', (): void => {
   testDate('lastUpdated');
 
   testBoolean('isServiceSpecific');
-  testBoolean('useNonStandardStacks');
+  testBoolean('useNonStandardTexts');
 
   testInstanceOf('purposeConsents', Vector);
   testInstanceOf('purposeLegitimateInterests', Vector);

--- a/modules/core/test/encoder/BitLength.test.ts
+++ b/modules/core/test/encoder/BitLength.test.ts
@@ -40,7 +40,7 @@ export function run(): void {
       expect(BitLength.segmentType, 'segmentType').to.equal(3);
       expect(BitLength.singleOrRange, 'singleOrRange').to.equal(1);
       expect(BitLength.specialFeatureOptins, 'specialFeatureOptins').to.equal(12);
-      expect(BitLength.useNonStandardStacks, 'useNonStandardStacks').to.equal(1);
+      expect(BitLength.useNonStandardTexts, 'useNonStandardTexts').to.equal(1);
       expect(BitLength.vendorId, 'vendorId').to.equal(16);
       expect(BitLength.vendorListVersion, 'vendorListVersion').to.equal(12);
       expect(BitLength.version, 'version').to.equal(6);

--- a/modules/core/test/encoder/sequence/FieldSequence.test.ts
+++ b/modules/core/test/encoder/sequence/FieldSequence.test.ts
@@ -52,7 +52,7 @@ describe('encoder/sequence->FieldSequence', (): void => {
       Fields.vendorListVersion,
       Fields.policyVersion,
       Fields.isServiceSpecific,
-      Fields.useNonStandardStacks,
+      Fields.useNonStandardTexts,
       Fields.specialFeatureOptins,
       Fields.purposeConsents,
       Fields.purposeLegitimateInterests,

--- a/modules/core/test/model/Fields.test.ts
+++ b/modules/core/test/model/Fields.test.ts
@@ -26,7 +26,7 @@ describe('model->Fields', (): void => {
       purposeLegitimateInterests: 'purposeLegitimateInterests',
       purposeOneTreatment: 'purposeOneTreatment',
       specialFeatureOptins: 'specialFeatureOptins',
-      useNonStandardStacks: 'useNonStandardStacks',
+      useNonStandardTexts: 'useNonStandardTexts',
       vendorConsents: 'vendorConsents',
       vendorLegitimateInterests: 'vendorLegitimateInterests',
       vendorListVersion: 'vendorListVersion',


### PR DESCRIPTION
Before TCF 2.2 the TCF supported the `useNonStandardStacks` flag as part of the `TCData` object. 

As part of the TCF 2.2 this flag is being replaced by `useNonStandardTexts`.