### PR TITLE
[TCF v2.2] restrict 3,4,5,6 purposes to consent legal basis

### DIFF
--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -20,9 +20,13 @@ export class SemanticPreEncoder {
       tcModel.publisherRestrictions.gvl = gvl;
 
       /**
-       * Purpose 1 is never allowed to be true for legitimate interest
+       * Purposes 1,3,4,5 and 6 is never allowed to be true for legitimate interest
        */
       tcModel.purposeLegitimateInterests.unset(1);
+      tcModel.purposeLegitimateInterests.unset(3);
+      tcModel.purposeLegitimateInterests.unset(4);
+      tcModel.purposeLegitimateInterests.unset(5);
+      tcModel.purposeLegitimateInterests.unset(6);
 
       /**
        * If a Vendor does not declare a purpose for consent or legitimate

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -49,6 +49,62 @@ describe('TCString', (): void => {
 
   });
 
+  it('should unset purposeLegitimateInterests 3 if it is set', (): void => {
+
+    const tcModel = getTCModel();
+    tcModel.purposeLegitimateInterests.set(3);
+
+    expect(tcModel.purposeLegitimateInterests.has(3), 'purposeLegitimateInterests.has(3)').to.be.true;
+
+    const encodedString = TCString.encode(tcModel);
+    const newModel = TCString.decode(encodedString);
+
+    expect(newModel.purposeLegitimateInterests.has(3), 'newModel.purposeLegitimateInterests.has(3)').to.be.false;
+
+  });
+
+  it('should unset purposeLegitimateInterests 4 if it is set', (): void => {
+
+    const tcModel = getTCModel();
+    tcModel.purposeLegitimateInterests.set(4);
+
+    expect(tcModel.purposeLegitimateInterests.has(4), 'purposeLegitimateInterests.has(4)').to.be.true;
+
+    const encodedString = TCString.encode(tcModel);
+    const newModel = TCString.decode(encodedString);
+
+    expect(newModel.purposeLegitimateInterests.has(4), 'newModel.purposeLegitimateInterests.has(4)').to.be.false;
+
+  });
+
+  it('should unset purposeLegitimateInterests 5 if it is set', (): void => {
+
+    const tcModel = getTCModel();
+    tcModel.purposeLegitimateInterests.set(5);
+
+    expect(tcModel.purposeLegitimateInterests.has(5), 'purposeLegitimateInterests.has(5)').to.be.true;
+
+    const encodedString = TCString.encode(tcModel);
+    const newModel = TCString.decode(encodedString);
+
+    expect(newModel.purposeLegitimateInterests.has(5), 'newModel.purposeLegitimateInterests.has(5)').to.be.false;
+
+  });
+
+  it('should unset purposeLegitimateInterests 6 if it is set', (): void => {
+
+    const tcModel = getTCModel();
+    tcModel.purposeLegitimateInterests.set(6);
+
+    expect(tcModel.purposeLegitimateInterests.has(6), 'purposeLegitimateInterests.has(6)').to.be.true;
+
+    const encodedString = TCString.encode(tcModel);
+    const newModel = TCString.decode(encodedString);
+
+    expect(newModel.purposeLegitimateInterests.has(6), 'newModel.purposeLegitimateInterests.has(6)').to.be.false;
+
+  });
+
   it('should set all vendorsDisclosed in the GVL when isServiceSpecific is false', (): void => {
 
     const tcModel = getTCModel();
@@ -174,9 +230,9 @@ describe('TCString', (): void => {
 
     tcModel.purposeLegitimateInterests.forEach((value: boolean, id: number): void => {
 
-      if ( id === 1 && value ) {
+      if ( [1, 3, 4, 5, 6].indexOf(id) !== -1 && value ) {
 
-        // id 1 gets unset on encoding for legitimate interests
+        // id 1, 3, 4, q5 and 6 gets unset on encoding for legitimate interests
 
         expect(newModel.purposeLegitimateInterests.has(id), `purposeLegitimateInterests.has(${id})`).to.be.false;
 


### PR DESCRIPTION
We need to prohibit to encode TCF v2.2 purposes 3,4,5 and 6 in `purposeLegitimateInterests` Vector based on the new policy  