### PR TITLE
CMP-4417: Avoid combining array from and set

### DIFF
--- a/modules/cli/package.json
+++ b/modules/cli/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint `find src -name '*.ts'`"
   },
   "dependencies": {
-    "@didomi/iabtcf-core": "1.5.8"
+    "@didomi/iabtcf-core": "1.5.9"
   },
   "devDependencies": {
     "@types/node": "^17.0.18",

--- a/modules/cmpapi/package.json
+++ b/modules/cmpapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-cmpapi",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Ensures other in-page digital marketing technologies have access to CMP transparency and consent information for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",
@@ -28,7 +28,7 @@
     "test-cov": "rm -rf coverage; nyc --reporter=html mocha"
   },
   "peerDependencies": {
-    "@didomi/iabtcf-core": ">=1.5.8"
+    "@didomi/iabtcf-core": ">=1.5.9"
   },
   "devDependencies": {
     "@didomi/iabtcf-stub": "1.5.6",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-core",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Ensures consistent encoding and decoding of TC Signals for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",

--- a/modules/core/src/encoder/field/PurposeRestrictionVectorEncoder.ts
+++ b/modules/core/src/encoder/field/PurposeRestrictionVectorEncoder.ts
@@ -14,7 +14,7 @@ export class PurposeRestrictionVectorEncoder {
     // if the vector is empty we'll just return a string with just the numRestricitons being 0
     if (!prVector.isEmpty()) {
 
-      const gvlVendorIds = Array.from(prVector.gvl.vendorIds);
+      const gvlVendorIds = [...prVector.gvl.vendorIds];
 
       const gvlHasVendorBetween = (vendorId: number, nextVendorId: number): boolean => {
 

--- a/modules/core/src/model/PurposeRestrictionVector.ts
+++ b/modules/core/src/model/PurposeRestrictionVector.ts
@@ -134,7 +134,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
    * @param {number[]|null|undefined} vendorsIds
    * @return {void}
    */
-  public restrictPurposeToLegalBasis(purposeRestriction: PurposeRestriction, vendorsIds: number[] = Array.from(this.gvl.vendorIds)): void {
+  public restrictPurposeToLegalBasis(purposeRestriction: PurposeRestriction, vendorsIds: number[] = [...this.gvl.vendorIds]): void {
 
     const hash: string = purposeRestriction.hash;
 
@@ -182,7 +182,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
       if (this.has(hash)) {
 
-        vendorIds = Array.from(this.map.get(hash));
+        vendorIds = [...this.map.get(hash)];
 
       }
 
@@ -192,7 +192,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
       this.map.forEach((vendorIds: Set<number>): void => {
 
-        Array.from(vendorIds).forEach((vendorId: number): void => {
+        [...vendorIds].forEach((vendorId: number): void => {
 
           vendorSet.add(vendorId);
 
@@ -200,7 +200,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
       });
 
-      vendorIds = Array.from(vendorSet);
+      vendorIds =[...vendorSet];
 
     }
 
@@ -266,7 +266,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
     this.map.forEach((purposeRestrictionVendorIds: Set<number>): void => {
 
-      const vendorIds = Array.from(purposeRestrictionVendorIds);
+      const vendorIds = [...purposeRestrictionVendorIds];
       result = Math.max(vendorIds[vendorIds.length - 1], result);
 
     });
@@ -311,7 +311,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
     });
 
-    return Array.from(purposeIds);
+    return [...purposeIds];
 
   }
 
@@ -363,7 +363,7 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
       this.map.forEach((vendorIds: Set<number>, hash: string): void => {
 
         const purposeRestriction: PurposeRestriction = PurposeRestriction.unHash(hash);
-        const vendors: number[] = Array.from(vendorIds);
+        const vendors: number[] = [...vendorIds];
 
         vendors.forEach((vendorId: number): void => {
 

--- a/modules/testing/package.json
+++ b/modules/testing/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint `find src -name '*.ts'`"
   },
   "peerDependencies": {
-    "@didomi/iabtcf-core": ">=1.5.8"
+    "@didomi/iabtcf-core": ">=1.5.9"
   },
   "dependencies": {
     "@types/sinon": "^10.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iabtcf",
-  "version": "1.5.6",
+  "version": "1.5.9",
   "description": "Official compliant tool suite for implementing the iab. Transparency and Consent Framework (TCF).",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
This MR replaces the pieces of code where `Array.from` is called for Sets

Sites that are using `prototype.js`  present the bug detailed here: https://didomi.slack.com/archives/C023NH4MJJZ/p1705500539890189

[CMP-4417](https://didomi.atlassian.net/browse/CMP-4417)

The `Array.from` implementation from the prototype library - returns an empty array whenever it's dealing with a `Set` value.
![Screenshot 2024-01-18 at 11 47 12](https://github.com/didomi/iabtcf-es/assets/30706016/2b116c53-9058-4bd0-be56-dc0f0a7b8764)

This is somehow similar to https://github.com/didomi/iabtcf-es/pull/2
And has been seen in the past
https://gitlab.com/didomi/sdks/web/core/-/merge_requests/517/diffs
https://gitlab.com/didomi/sdks/web/core/-/merge_requests/765/diffs
