### PR TITLE
Merge pull request #389 from InteractiveAdvertisingBureau/388

### DIFF
--- a/modules/cli/package.json
+++ b/modules/cli/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint `find src -name '*.ts'`"
   },
   "dependencies": {
-    "@didomi/iabtcf-core": "1.5.9"
+    "@didomi/iabtcf-core": "1.6.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.18",

--- a/modules/cmpapi/package.json
+++ b/modules/cmpapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-cmpapi",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "description": "Ensures other in-page digital marketing technologies have access to CMP transparency and consent information for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",
@@ -28,7 +28,7 @@
     "test-cov": "rm -rf coverage; nyc --reporter=html mocha"
   },
   "peerDependencies": {
-    "@didomi/iabtcf-core": ">=1.5.9"
+    "@didomi/iabtcf-core": ">=1.6.0"
   },
   "devDependencies": {
     "@didomi/iabtcf-stub": "1.5.6",

--- a/modules/cmpapi/src/CmpApi.ts
+++ b/modules/cmpapi/src/CmpApi.ts
@@ -23,7 +23,7 @@ export class CmpApi {
 
     CmpApiModel.cmpId = cmpId;
     CmpApiModel.cmpVersion = cmpVersion;
-    CmpApiModel.tcfPolicyVersion = 2;
+    CmpApiModel.tcfPolicyVersion = 4;
 
     this.isServiceSpecific = !!isServiceSpecific;
     this.callResponder = new CallResponder(customCommands);

--- a/modules/cmpapi/test/response/Ping.test.ts
+++ b/modules/cmpapi/test/response/Ping.test.ts
@@ -8,6 +8,12 @@ import {expect} from 'chai';
 
 describe('response->Ping', (): void => {
 
+  beforeEach(function() {
+
+    CmpApiModel.reset();
+
+  });
+
   const isAGoodPing = (ping: Ping): void => {
 
     expect(ping.cmpLoaded, 'ping.cmpLoaded').to.be.true;

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/iabtcf-core",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "description": "Ensures consistent encoding and decoding of TC Signals for the iab. Transparency and Consent Framework (TCF).",
   "author": "Chris Paterson <tcf@chrispaterson.io>",
   "homepage": "https://iabtcf.com/",

--- a/modules/core/src/TCModel.ts
+++ b/modules/core/src/TCModel.ts
@@ -21,7 +21,7 @@ export class TCModel extends Cloneable<TCModel> {
   private publisherCountryCode_ = 'AA';
   private version_ = 2;
   private consentScreen_: StringOrNumber = 0;
-  private policyVersion_: StringOrNumber = 2;
+  private policyVersion_: StringOrNumber = 4;
   private consentLanguage_ = 'EN';
   private cmpId_: StringOrNumber = 0;
   private cmpVersion_: StringOrNumber = 0;

--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -21,8 +21,9 @@ export class SemanticPreEncoder {
 
       /**
        * Purpose 1 is never allowed to be true for legitimate interest
+       * As of TCF v2.2 purposes 3,4,5 & 6 are not allowed to be true for LI
        */
-      tcModel.purposeLegitimateInterests.unset(1);
+      tcModel.purposeLegitimateInterests.unset([1, 3, 4, 5, 6]);
 
       /**
        * If a Vendor does not declare a purpose for consent or legitimate

--- a/modules/core/test/TCModel.test.ts
+++ b/modules/core/test/TCModel.test.ts
@@ -143,7 +143,7 @@ describe('TCModel', (): void => {
 
     // since we didn't construct with a gvl we should
     // have empty fields here
-    expect(tcModel.vendorListVersion).to.equal(0); expect(tcModel.policyVersion).to.equal(2);
+    expect(tcModel.vendorListVersion).to.equal(0); expect(tcModel.policyVersion).to.equal(4);
     expect(tcModel.gvl).to.be.undefined;
 
   });

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -35,17 +35,25 @@ describe('TCString', (): void => {
 
   });
 
-  it('should unset purposeLegitimateInterests 1 if it is set', (): void => {
+  it('should unset purposeLegitimateInterests 1, 3, 4, 5 & 6 if it is set', (): void => {
 
     const tcModel = getTCModel();
-    tcModel.purposeLegitimateInterests.set(1);
+    tcModel.purposeLegitimateInterests.set([1, 3, 4, 5, 6]);
 
     expect(tcModel.purposeLegitimateInterests.has(1), 'purposeLegitimateInterests.has(1)').to.be.true;
+    expect(tcModel.purposeLegitimateInterests.has(3), 'purposeLegitimateInterests.has(3)').to.be.true;
+    expect(tcModel.purposeLegitimateInterests.has(4), 'purposeLegitimateInterests.has(4)').to.be.true;
+    expect(tcModel.purposeLegitimateInterests.has(5), 'purposeLegitimateInterests.has(5)').to.be.true;
+    expect(tcModel.purposeLegitimateInterests.has(6), 'purposeLegitimateInterests.has(6)').to.be.true;
 
     const encodedString = TCString.encode(tcModel);
     const newModel = TCString.decode(encodedString);
 
     expect(newModel.purposeLegitimateInterests.has(1), 'newModel.purposeLegitimateInterests.has(1)').to.be.false;
+    expect(newModel.purposeLegitimateInterests.has(3), 'newModel.purposeLegitimateInterests.has(3)').to.be.false;
+    expect(newModel.purposeLegitimateInterests.has(4), 'newModel.purposeLegitimateInterests.has(4)').to.be.false;
+    expect(newModel.purposeLegitimateInterests.has(5), 'newModel.purposeLegitimateInterests.has(5)').to.be.false;
+    expect(newModel.purposeLegitimateInterests.has(6), 'newModel.purposeLegitimateInterests.has(6)').to.be.false;
 
   });
 
@@ -174,9 +182,9 @@ describe('TCString', (): void => {
 
     tcModel.purposeLegitimateInterests.forEach((value: boolean, id: number): void => {
 
-      if ( id === 1 && value ) {
+      if ( (id === 1 || id >= 3 && id <= 6) && value ) {
 
-        // id 1 gets unset on encoding for legitimate interests
+        // id 1, 3, 4, 5 & 6 gets unset on encoding for legitimate interests
 
         expect(newModel.purposeLegitimateInterests.has(id), `purposeLegitimateInterests.has(${id})`).to.be.false;
 

--- a/modules/testing/package.json
+++ b/modules/testing/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint `find src -name '*.ts'`"
   },
   "peerDependencies": {
-    "@didomi/iabtcf-core": ">=1.5.9"
+    "@didomi/iabtcf-core": ">=1.6.0"
   },
   "dependencies": {
     "@types/sinon": "^10.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iabtcf",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "description": "Official compliant tool suite for implementing the iab. Transparency and Consent Framework (TCF).",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Bring the MR https://github.com/InteractiveAdvertisingBureau/iabtcf-es/pull/389 from the original repo to our fork as we want to update the policyVersion to 4

Update to support TCF v2.2 (issue #388). Also fixed an error in the test script

Changes listed in the original MR:
Updated set the purpose LI purposes 3 - 6 to always be set to 0. (No LI allowed).
Updated the policy version from 2 and 4.
Fixed broken test, and update test to support the above change.